### PR TITLE
Build broken - xtend-maven-plugin must run after *.mwe2!

### DIFF
--- a/my.mavenized.herolanguage.releng/pom.xml
+++ b/my.mavenized.herolanguage.releng/pom.xml
@@ -33,6 +33,34 @@
 	</repositories>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<!-- xtend-maven-plugin is in pluginManagement instead of in plugins
+					 so that it doesn't run before the exec-maven-plugin's *.mwe2 gen;
+					 this way we can list it after. 
+				  -->
+				  
+				<plugin>
+					<groupId>org.eclipse.xtend</groupId>
+					<artifactId>xtend-maven-plugin</artifactId>
+					<version>${xtext.version}</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>compile</goal>
+								<goal>xtend-install-debug-info</goal>
+								<goal>testCompile</goal>
+								<goal>xtend-test-install-debug-info</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<outputDirectory>xtend-gen</outputDirectory>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
@@ -59,24 +87,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.xtend</groupId>
-				<artifactId>xtend-maven-plugin</artifactId>
-				<version>${xtext.version}</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compile</goal>
-							<goal>xtend-install-debug-info</goal>
-							<goal>testCompile</goal>
-							<goal>xtend-test-install-debug-info</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<outputDirectory>xtend-gen</outputDirectory>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/my.mavenized.herolanguage.tests/pom.xml
+++ b/my.mavenized.herolanguage.tests/pom.xml
@@ -17,6 +17,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.eclipse.xtend</groupId>
+        <artifactId>xtend-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>

--- a/my.mavenized.herolanguage.ui/pom.xml
+++ b/my.mavenized.herolanguage.ui/pom.xml
@@ -13,4 +13,13 @@
   <packaging>eclipse-plugin</packaging>
 
   <name>My Hero Language UI</name>
+  
+  <build>
+  	<plugins>
+  		<plugin>
+  			<groupId>org.eclipse.xtend</groupId>
+			<artifactId>xtend-maven-plugin</artifactId>
+		</plugin>
+  	</plugins>
+  </build>
 </project>

--- a/my.mavenized.herolanguage/pom.xml
+++ b/my.mavenized.herolanguage/pom.xml
@@ -44,6 +44,10 @@
 					</dependency>
 				</dependencies>
 			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
When I try this out (as of https://github.com/svenefftinge/maven-xtext-example/commit/e48ec465d93811a407825659316d421146b283c9), as in CLI git clone the repo, without any Eclipse IDE with some Xtend Builder kicking in, like e.g. a CI server would, then it doesn't actually work... I'm getting the error shown below.

This is because the xtend-maven-plugin is running BEFORE the exec-maven-plugin ran the *.mwe2 - which cannot work.

This PR fixes that, by declaring the xtend-maven-plugin only in pluginManagement instead of plugin in the parent pom.xml, and then listing it (only with groupId & artifactId; executions and configuration are inherited) in the core/ui/test pom.xml AFTER the exec-maven-plugin (in the core) or BEFORE the tycho-surefire-plugin (in .test).

If you / anyone else knows of a better way than this to control the execution order of plugins, avoiding redeclaration of xtend-maven-plugin in 4 places, that would obviously be even better - but this works.

`[INFO] ------------------------------------------------------------------------
[INFO] Building My Hero Language Core 1.0.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.4.1:clean (default-clean) @ my.mavenized.herolanguage ---
[INFO] Deleting /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/target
[INFO] 
[INFO] --- tycho-packaging-plugin:0.15.0:build-qualifier (default-build-qualifier) @ my.mavenized.herolanguage ---
[INFO] 
[INFO] --- tycho-packaging-plugin:0.15.0:validate-id (default-validate-id) @ my.mavenized.herolanguage ---
[INFO] 
[INFO] --- tycho-packaging-plugin:0.15.0:validate-version (default-validate-version) @ my.mavenized.herolanguage ---
[INFO] 
[INFO] --- xtend-maven-plugin:2.5.0-SNAPSHOT:compile (default) @ my.mavenized.herolanguage ---
[ERROR] 
ERROR:  HeroLanguageValidator.xtend - /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/src/my/mavenized/validation/HeroLanguageValidator.xtend
12: AbstractHeroLanguageValidator cannot be resolved to a type.
[ERROR] 
ERROR:  HeroLanguageValidator.xtend - /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/src/my/mavenized/validation/HeroLanguageValidator.xtend
12: Superclass must be a class
[ERROR] 
ERROR:  HeroLanguageJvmModelInferrer.xtend - /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/src/my/mavenized/jvmmodel/HeroLanguageJvmModelInferrer.xtend
4: my.mavenized.heroLanguage.Heros cannot be resolved to a type.
[ERROR] 
ERROR:  HeroLanguageJvmModelInferrer.xtend - /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/src/my/mavenized/jvmmodel/HeroLanguageJvmModelInferrer.xtend
47: Heros cannot be resolved to a type.
[ERROR] 
ERROR:  HeroLanguageJvmModelInferrer.xtend - /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/src/my/mavenized/jvmmodel/HeroLanguageJvmModelInferrer.xtend
49: The method name is undefined for the type HeroLanguageJvmModelInferrer
[ERROR] 
ERROR:  HeroLanguageJvmModelInferrer.xtend - /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/src/my/mavenized/jvmmodel/HeroLanguageJvmModelInferrer.xtend
51: The method name is undefined for the type HeroLanguageJvmModelInferrer
[ERROR] 
ERROR:  HeroLanguageJvmModelInferrer.xtend - /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/src/my/mavenized/jvmmodel/HeroLanguageJvmModelInferrer.xtend
52: The method someCode is undefined for the type HeroLanguageJvmModelInferrer
[ERROR] 
ERROR:  HeroLanguageJvmModelInferrer.xtend - /home/vorburger/dev/3rd-party/maven-xtext-example/my.mavenized.herolanguage/src/my/mavenized/jvmmodel/HeroLanguageJvmModelInferrer.xtend
52: Ambiguous feature call.
The extension methods
    setBody(JvmExecutable, StringConcatenationClient) in JvmTypesBuilder,
    setBody(JvmExecutable, Procedure1<ITreeAppendable>) in JvmTypesBuilder and
    setBody(JvmExecutable, XExpression) in JvmTypesBuilder
all match.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] parent ............................................ SUCCESS [3.667s]
[INFO] My Hero Language Core ............................. FAILURE [8.013s]
[INFO] My Hero Language UI ............................... SKIPPED
[INFO] My Hero Language Tests ............................ SKIPPED
[INFO] My Hero Language Feature .......................... SKIPPED
[INFO] My Hero Language Update Site ...................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 40.834s
[INFO] Finished at: Sat Nov 23 00:27:53 CET 2013
[INFO] Final Memory: 113M/605M
[INFO] ------------------------------------------------------------------------`

This is because 
