### PR TITLE
Automatically create language artifacts on project import

### DIFF
--- a/my.mavenized.herolanguage.releng/pom.xml
+++ b/my.mavenized.herolanguage.releng/pom.xml
@@ -19,7 +19,15 @@
 		<xtext.version>2.5.0-SNAPSHOT</xtext.version>
 	</properties>
 
+
+
+
 	<repositories>
+		<repository>
+			<id>fornax.repository</id>
+			<name>Fornax Repository</name>
+			<url>http://www.fornax-platform.org/m2/repository</url>
+		</repository>
 		<repository>
 			<id>kepler</id>
 			<layout>p2</layout>
@@ -30,27 +38,31 @@
 			<layout>p2</layout>
 			<url>http://download.eclipse.org/modeling/tmf/xtext/updates/composite/latest/</url>
 		</repository>
-		
-        <repository>
-          <id>central snapshots</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </repository>
+
+		<repository>
+			<id>central snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+		</repository>
 	</repositories>
 	<pluginRepositories>
 		<pluginRepository>
 			<id>central snapshots</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 		</pluginRepository>
+		<pluginRepository>
+			<id>fornax.plugin.repository</id>
+			<name>Fornax Plugin Repository</name>
+			<url>http://www.fornax-platform.org/m2/repository</url>
+		</pluginRepository>
 	</pluginRepositories>
 
 	<build>
 		<pluginManagement>
 			<plugins>
-				<!-- xtend-maven-plugin is in pluginManagement instead of in plugins
-					 so that it doesn't run before the exec-maven-plugin's *.mwe2 gen;
-					 this way we can list it after. 
-				  -->
-				  
+				<!-- xtend-maven-plugin is in pluginManagement instead of in plugins 
+					so that it doesn't run before the exec-maven-plugin's *.mwe2 gen; this way 
+					we can list it after. -->
+
 				<plugin>
 					<groupId>org.eclipse.xtend</groupId>
 					<artifactId>xtend-maven-plugin</artifactId>
@@ -71,7 +83,7 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		
+
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>

--- a/my.mavenized.herolanguage/pom.xml
+++ b/my.mavenized.herolanguage/pom.xml
@@ -16,56 +16,52 @@
 
 	<build>
 		<plugins>
-			        <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-clean-plugin</artifactId>
-                  <version>2.5</version>
-                  <configuration>
-                          <filesets>
-                                  <fileset>
-                                          <directory>${basedir}/src-gen</directory>
-                                  </fileset>
-                                  <fileset>
-                                          <directory>${basedir}/xtend-gen</directory>
-                                  </fileset>
-                                  <!-- clean ui plugin as well -->
-                                  <fileset>
-                                          <directory>${basedir}/../${project.artifactId}.ui/src-gen</directory>
-                                  </fileset>
-                                  <fileset>
-                                          <directory>${basedir}/../${project.artifactId}.ui/xtend-gen</directory>
-                                  </fileset>
-                                  <!-- clean test fragment as well -->
-                                  <fileset>
-                                          <directory>${basedir}/../${project.artifactId}.tests/src-gen</directory>
-                                  </fileset>
-                                  <fileset>
-                                          <directory>${basedir}/../${project.artifactId}.tests/xtend-gen</directory>
-                                  </fileset>
-                          </filesets>
-                  </configuration>
-                  </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+				<version>2.5</version>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>${basedir}/src-gen</directory>
+						</fileset>
+						<fileset>
+							<directory>${basedir}/xtend-gen</directory>
+						</fileset>
+						<!-- clean ui plugin as well -->
+						<fileset>
+							<directory>${basedir}/../${project.artifactId}.ui/src-gen</directory>
+						</fileset>
+						<fileset>
+							<directory>${basedir}/../${project.artifactId}.ui/xtend-gen</directory>
+						</fileset>
+						<!-- clean test fragment as well -->
+						<fileset>
+							<directory>${basedir}/../${project.artifactId}.tests/src-gen</directory>
+						</fileset>
+						<fileset>
+							<directory>${basedir}/../${project.artifactId}.tests/xtend-gen</directory>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<version>1.2.1</version>
+				<groupId>org.fornax.toolsupport</groupId>
+				<artifactId>fornax-oaw-m2-plugin</artifactId>
+				<version>3.4.0</version>
 				<executions>
 					<execution>
+						<id>generate-language-artifacts</id>
 						<phase>generate-sources</phase>
 						<goals>
-							<goal>java</goal>
+							<goal>run-workflow</goal>
 						</goals>
+						<configuration>
+							<workflowDescriptor>src/my/mavenized/GenerateHeroLanguage.mwe2</workflowDescriptor>
+						</configuration>
 					</execution>
 				</executions>
-				<configuration>
-					<includeProjectDependencies>false</includeProjectDependencies>
-					<includePluginDependencies>true</includePluginDependencies>
-					<mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
-					<arguments>
-						<argument>${project.basedir}/src/my/mavenized/GenerateHeroLanguage.mwe2</argument>
-					</arguments>
-				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>
@@ -79,5 +75,41 @@
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											org.fornax.toolsupport
+										</groupId>
+										<artifactId>
+											fornax-oaw-m2-plugin
+										</artifactId>
+										<versionRange>
+											[3.4.0,)
+										</versionRange>
+										<goals>
+											<goal>run-workflow</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<execute>
+											<runOnIncremental>false</runOnIncremental>
+										</execute>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>


### PR DESCRIPTION
I replaced the exec-plugin with the better-suited fornax-oaw-plugin. It is called when you "Import as Maven Project" or "Checkout as Maven Project" from Eclipse. This way, when people check out the project, they don't need to manually run the GenerateHeroLanguage workflow.
