### PR TITLE
standalone

### DIFF
--- a/example-standalone-usage/.classpath
+++ b/example-standalone-usage/.classpath
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry including="**/*.java" kind="src" path="src/test/resources"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/example-standalone-usage/.classpath
+++ b/example-standalone-usage/.classpath
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="src" path="src/test/resources"/>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/example-standalone-usage/.project
+++ b/example-standalone-usage/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>example-standalone-usage</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/example-standalone-usage/.settings/org.eclipse.jdt.core.prefs
+++ b/example-standalone-usage/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,12 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.5

--- a/example-standalone-usage/.settings/org.eclipse.m2e.core.prefs
+++ b/example-standalone-usage/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/example-standalone-usage/pom.xml
+++ b/example-standalone-usage/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<relativePath>../my.mavenized.herolanguage.releng/pom.xml</relativePath>
+		<groupId>my.mavenized.herolanguage</groupId>
+		<artifactId>parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>example-standalone-usage</artifactId>
+	<!-- NOT <packaging>eclipse-plugin</packaging>, but default (standard SE jar, with normal Maven-based dependencies) -->
+
+	<dependencies>
+		<dependency>
+			<groupId>my.mavenized.herolanguage</groupId>
+			<artifactId>my.mavenized.herolanguage</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext.xbase</artifactId>
+			<!--  OR just <artifactId>org.eclipse.xtext</artifactId> if your lang doesn't use xbase -->
+			<version>${xtext.version}</version>
+			<exclusions>
+				<!-- JDT etc. etc. not needed simply for parsing models -->
+				<exclusion>
+					<artifactId>org.eclipse.xtext.dependencies</artifactId>
+					<groupId>org.eclipse.xtext</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/example-standalone-usage/src/main/java/my/mavenized/standalone/StandaloneXtext.java
+++ b/example-standalone-usage/src/main/java/my/mavenized/standalone/StandaloneXtext.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+   * Copyright (c) 2013 Michael Vorburger.
+   * All rights reserved. This program and the accompanying materials
+   * are made available under the terms of the Eclipse Public License v1.0
+   * which accompanies this distribution, and is available at
+   * http://www.eclipse.org/legal/epl-v10.html
+   * 
+   * Contributors:
+   *     Michael Vorburger - initial API and implementation
+   ******************************************************************************/
+package my.mavenized.standalone;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.ISetup;
+import org.eclipse.xtext.junit4.GlobalRegistries;
+import org.eclipse.xtext.junit4.IInjectorProvider;
+import org.eclipse.xtext.junit4.util.ParseHelper;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+/**
+ * Utility to bootstrap Xtext-based grammars in standalone scenarios.
+ * 
+ * Intended to hide Xtext/Guice/EMF internals from simple client apps.
+ * 
+ * This should typically be used as a Singleton, and bootstrapped once
+ * at a suitable lifecycle event of the client application (main() method,
+ * Servlet Context Listener, etc.).
+ * 
+ * This basically does something similar to the respective gen. YourLanguageInjectorProvider from yourlang.tests/src-gen.
+ * 
+ * REPEAT: This class is intended for usage in STANDALONE scenarios only.
+ * Standalone in Xtext terminology means something like "running outside of an
+ * Eclipse IDE, typically plain Java SE" (or EE, if you must). Note that e.g. a
+ * headless Eclipse product is NOT a standalone scenario.
+ * 
+ * @author Michael Vorburger
+ */
+public class StandaloneXtext<T extends EObject> implements IInjectorProvider {
+	// implements IInjectorProvider isn't terribly important - could be removed if it causes any hassles
+	
+	static {
+		GlobalRegistries.initializeDefaults();
+	}
+
+	// Always use com.google.inject.Inject instead of javax.inject.Inject here,
+	// just to play it safe and avoid known problems typically encountered e.g.
+	// when using the Spring Framework, wherein EE containers attempt to inject
+	// stuff when you do not want them to....
+
+	protected @Inject Injector injector;
+
+	@SuppressWarnings("rawtypes")
+	// Guice fails with: "ParseHelper<T> cannot be used as a key; It is not fully specified."
+	// if we use ParseHelper<T> here, so we have to do it like this, and implicitly cast in getParseHelper() below.. :-( 
+	protected @Inject ParseHelper parseHelper;
+
+	protected StandaloneXtext() {
+	}
+	
+	public StandaloneXtext(Injector injector) {
+		injector.injectMembers(this);
+	}
+
+	public StandaloneXtext(ISetup iSetup) {
+		this(iSetup.createInjectorAndDoEMFRegistration());
+	}
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param iSetupClass the respective YourLanguageStandaloneSetupGenerated.class from yourlang/src-gen.
+	 */
+	public StandaloneXtext(Class<ISetup> iSetupClass) {
+		this(newISetup(iSetupClass));
+	}
+
+	private static ISetup newISetup(Class<ISetup> iSetupClass) {
+		try {
+			return iSetupClass.newInstance();
+		} catch (InstantiationException e) {
+			throw new IllegalArgumentException("newInstance() failed for " + iSetupClass.toString(), e);
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException("newInstance() failed for " + iSetupClass.toString(), e);
+		} 
+	}
+
+	@SuppressWarnings("unchecked") // see note in parseHelper
+	public ParseHelper<T> getParseHelper() {
+		Preconditions.checkNotNull(parseHelper, StandaloneXtext.class.getName() + " hasn't been initialized correctly");
+		return parseHelper;
+	}
+	
+	/**
+	 * Get the Guice Injector for this language.
+	 * Normally you shouldn't have to use the Guice API directly, but use dependency injection everywhere.
+	 * Sometimes it's useful though.
+	 */
+	public Injector getInjector() {
+		Preconditions.checkNotNull(injector, StandaloneXtext.class.getName() + " hasn't been initialized correctly");
+		return injector;
+	}	
+}

--- a/example-standalone-usage/src/test/java/my/mavenized/standalone/tests/SimpleParsingTest.java
+++ b/example-standalone-usage/src/test/java/my/mavenized/standalone/tests/SimpleParsingTest.java
@@ -1,0 +1,29 @@
+package my.mavenized.standalone.tests;
+
+import static org.junit.Assert.assertEquals;
+import my.mavenized.HeroLanguageStandaloneSetupGenerated;
+import my.mavenized.heroLanguage.Heros;
+import my.mavenized.standalone.StandaloneXtext;
+
+import org.junit.Test;
+
+/**
+ * Uses the XtextStandaloneUtil instead of the classic Xtext JUnit helpers you
+ * would normally use (@RunWith(XtextRunner.class) @InjectWith(HeroLanguageInjectorProvider.class)),
+ * if this was not a standalone example but an eclipse-test-plugin, to illustrate
+ * more generally how Xtext can be, via Maven, in standalone (non-Test) code.
+ * 
+ * Also e.g. HeroLanguageInjectorProvider isn't easily available in such a standalone module because it's generated in the *.test bundle.
+ */
+public class SimpleParsingTest {
+
+	@Test
+	@SuppressWarnings({ "rawtypes", "unchecked" }) // TODO how to avoid this?!
+	public void testXtextStandaloneUtilForSimpleParsing() throws Exception {
+		StandaloneXtext<Heros> xtextBootstrap = new StandaloneXtext(HeroLanguageStandaloneSetupGenerated.class);
+		String heroesText = "hero superman can FLY\nhero iceman can ICE";
+		Heros eHeroes = xtextBootstrap.getParseHelper().parse(heroesText);
+		assertEquals(2, eHeroes.getHeros().size());
+	}
+
+}

--- a/my.mavenized.herolanguage.releng/pom.xml
+++ b/my.mavenized.herolanguage.releng/pom.xml
@@ -11,6 +11,8 @@
 		<module>../my.mavenized.herolanguage.tests</module>
 		<module>../my.mavenized.herolanguage.sdk</module>
 		<module>../my.mavenized.herolanguage.updatesite</module>
+		
+		<module>../example-standalone-usage</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION
How about having (something like) this as part of this example/template? 

It illustrates a "standalone" usage scenario, incl. respective needed Maven configuration, as well as a proposed convenience helper class (which you may want to rewrite better - I'll take no offence at all).

I came up with this as a preparation for what I want to do in https://github.com/vorburger/eclipse-typescript-xtext/issues/11 some other time.
