### PR TITLE
README notes re. grammarURI change needed in *.mwe2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ Steps:
  cd ../example-project/
  mvn clean install
 ```
+
+Noteworthy changes to make manually to your grammar created by the Xtext Wizard
+===============================================================================
+
+At least if you are migrating from a pre-2.5 grammar (unclear if in v2.5 this will be OOB),
+please note that you'll have to change the grammarURI in your resp. Generate*.mwe2
+from classpath:/ to platform:/ - as per the example GenerateHeroLanguage.mwe2,
+otherwise you'll hit:
+
+   ERROR mf.mwe2.launch.runtime.Mwe2Launcher  - Problems instantiating module ...Generate*
+   Caused by: org.eclipse.xtext.resource.ClasspathUriResolutionException: org.eclipse.xtext.resource.FileNotFoundOnClasspathException: Couldn't find resource on classpath. URI was 'classpath:/.../*.xtext'


### PR DESCRIPTION
This is something I stumbled across, and took me a minute to figure out while I was applying this maven-xtext-example to my https://github.com/vorburger/eclipse-typescript-xtext... may be a few words of doc about this are helpful to others in the future?

Depending on whether the New Project wizard in Xtext v2.5 has already been adapted to do this this, the wording of the doc should may be changed, and/or this is something that could be adapted as part of https://bugs.eclipse.org/bugs/show_bug.cgi?id=422375 in the future some day?

PS: I've noticed that there were some other differences in the GenerateHeroLanguage.mwe2 as well, which I didn't have in a 2.4 Wizard-based project (+resourceSet, +uriMap, -scanClassPath, +forcedResourceSet = theResourceSet) - no idea if those are relevant in this context?
