### PR TITLE
project mapping for builds without .project file

### DIFF
--- a/my.mavenized.herolanguage/src/my/mavenized/GenerateHeroLanguage.mwe2
+++ b/my.mavenized.herolanguage/src/my/mavenized/GenerateHeroLanguage.mwe2
@@ -27,7 +27,13 @@ Workflow {
     		from = "platform:/resource/org.eclipse.xtext.common.types/"
     		to = "classpath:/"
     	}
-    	
+
+    	// for builds without .project file
+    	projectMapping = {
+		projectName = '${projectName}' 
+		path = '${runtimeProject}'
+	}
+
     	// register current projects and its siblings for platform URI map, as they are not on the classpath.
     	platformUri = "${runtimeProject}/.."
     	// The following two lines can be removed, if Xbase is not used.


### PR DESCRIPTION
The .project file is used by the workflow to derive the project path. If it is not checked in, the workflow needs an explicit project mapping so that build servers can check out the projects and build successfully.

Signed-off-by: Dietmar Stoll eclipse.etc@dietmar-stoll.de