### PR TITLE
Fixed builds with Java 11 as Host JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - openjdk11
 os:
   - linux
 cache:

--- a/example-project-gradle/build.gradle
+++ b/example-project-gradle/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 repositories {
+    
     mavenLocal() // This is required so that the herolanguage (which you previously 'mvn install' using Tycho) is found  
     jcenter()
 }
@@ -16,6 +17,9 @@ dependencies {
     compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.16.0'
     testCompile 'junit:junit:4.12'
 }
+
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
 
 xtext {
     languages {

--- a/example-project/pom.xml
+++ b/example-project/pom.xml
@@ -7,6 +7,8 @@
 	<version>0.0.1-SNAPSHOT</version>
 
 	<properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<xtext-version>2.16.0</xtext-version>
 	</properties>

--- a/my.mavenized.herolanguage.tests/pom.xml
+++ b/my.mavenized.herolanguage.tests/pom.xml
@@ -32,6 +32,25 @@
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<configuration>
+					<dependency-resolution>
+						<extraRequirements>
+							<!-- to get the org.eclipse.osgi.compatibility.state plugin
+							if the target platform is Luna or later.
+							(backward compatible with kepler and previous versions)
+							see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492149 -->
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.eclipse.rcp</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	</modules>
 	
 	<properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<tycho-version>1.3.0</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<xtext.version>2.16.0</xtext.version>


### PR DESCRIPTION
Fixed builds with Java 11 as Host JDK
workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=539038

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>