### PR TITLE
Fixed problems with Java 11 and Tycho + Xtext 2.17

### DIFF
--- a/example-project-gradle/build.gradle
+++ b/example-project-gradle/build.gradle
@@ -1,8 +1,8 @@
 
 plugins {
   id "eclipse"
-  id "org.xtext.xtend" version "2.0.2"
-  id "org.xtext.builder" version "2.0.2"
+  id "org.xtext.xtend" version "2.0.4"
+  id "org.xtext.builder" version "2.0.4"
 }
 
 repositories {
@@ -14,7 +14,7 @@ repositories {
 dependencies {
     xtextLanguages 'my.mavenized.herolanguage:my.mavenized.herolanguage:1.0.0-SNAPSHOT'
 
-    compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.16.0'
+    compile 'org.eclipse.xtend:org.eclipse.xtend.lib:2.17.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/example-project/pom.xml
+++ b/example-project/pom.xml
@@ -10,7 +10,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<xtext-version>2.16.0</xtext-version>
+		<xtext-version>2.17.0</xtext-version>
 	</properties>
 
 	<dependencies>

--- a/my.mavenized.herolanguage.tests/pom.xml
+++ b/my.mavenized.herolanguage.tests/pom.xml
@@ -32,25 +32,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>target-platform-configuration</artifactId>
-				<configuration>
-					<dependency-resolution>
-						<extraRequirements>
-							<!-- to get the org.eclipse.osgi.compatibility.state plugin
-							if the target platform is Luna or later.
-							(backward compatible with kepler and previous versions)
-							see https://bugs.eclipse.org/bugs/show_bug.cgi?id=492149 -->
-							<requirement>
-								<type>eclipse-feature</type>
-								<id>org.eclipse.rcp</id>
-								<versionRange>0.0.0</versionRange>
-							</requirement>
-						</extraRequirements>
-					</dependency-resolution>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>

--- a/my.mavenized.herolanguage/pom.xml
+++ b/my.mavenized.herolanguage/pom.xml
@@ -46,7 +46,7 @@
 					<dependency>
 						<groupId>org.eclipse.emf</groupId>
 						<artifactId>org.eclipse.emf.mwe2.launch</artifactId>
-						<version>2.9.1.201705291010</version>
+						<version>2.10.0</version>
 					</dependency>
 					<dependency>
 						<groupId>org.eclipse.xtext</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,16 +20,16 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<tycho-version>1.3.0</tycho-version>
+		<tycho-version>1.4.0</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<xtext.version>2.16.0</xtext.version>
+		<xtext.version>2.17.0</xtext.version>
 	</properties>
 
 	<repositories>
 		<repository>
 			<id>eclipse</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/2018-12/</url>
+			<url>http://download.eclipse.org/releases/2019-03/</url>
 		</repository>
 		<repository>
 			<id>Xtext Update Site</id>


### PR DESCRIPTION
Fixed problems with Java 11 and Tycho
https://github.com/eclipse/xtext-core/issues/937

Updated to Xtext 2.17
https://github.com/xtext/maven-xtext-example/issues/59

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>