### PR TITLE
remove unnecessary P2 repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,16 +32,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 			<layout>p2</layout>
 			<url>https://download.eclipse.org/releases/2022-09/</url>
 		</repository>
-		<repository>
-			<id>Xtext Update Site</id>
-			<layout>p2</layout>
-			<url>https://download.eclipse.org/modeling/tmf/xtext/updates/releases/${xtext.version}/</url>
-		</repository>
-		<repository>
-			<id>mwe</id>
-			<layout>p2</layout>
-			<url>https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.13.0/</url>
-		</repository>
 	</repositories>
 	
 	<build>


### PR DESCRIPTION
Since everything is contained in the Eclipse Release Train the additional URLs are not required.