### PR TITLE
Add eclipse metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.*
 !/.gitignore
 !/.gitkeep
 !.github

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/my.mavenized.herolanguage.ide/.project
+++ b/my.mavenized.herolanguage.ide/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>my.mavenized.herolanguage.ide</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/my.mavenized.herolanguage.ide/.settings/org.eclipse.core.resources.prefs
+++ b/my.mavenized.herolanguage.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/my.mavenized.herolanguage.ide/.settings/org.eclipse.m2e.core.prefs
+++ b/my.mavenized.herolanguage.ide/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/my.mavenized.herolanguage.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/my.mavenized.herolanguage.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,7 @@
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/main/java.directory=xtend-gen
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/test/java.directory=src/test/generated-sources/xtend
+BuilderConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
+outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
+outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/my.mavenized.herolanguage.sdk/.project
+++ b/my.mavenized.herolanguage.sdk/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>my.mavenized.herolanguage.sdk</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/my.mavenized.herolanguage.sdk/.settings/org.eclipse.core.resources.prefs
+++ b/my.mavenized.herolanguage.sdk/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/my.mavenized.herolanguage.sdk/.settings/org.eclipse.m2e.core.prefs
+++ b/my.mavenized.herolanguage.sdk/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/my.mavenized.herolanguage.tests/.project
+++ b/my.mavenized.herolanguage.tests/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>my.mavenized.herolanguage.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/my.mavenized.herolanguage.tests/.settings/org.eclipse.core.resources.prefs
+++ b/my.mavenized.herolanguage.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/my.mavenized.herolanguage.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/my.mavenized.herolanguage.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/my.mavenized.herolanguage.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/my.mavenized.herolanguage.tests/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,7 @@
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/main/java.directory=xtend-gen
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/test/java.directory=src/test/generated-sources/xtend
+BuilderConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
+outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
+outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/my.mavenized.herolanguage.ui/.project
+++ b/my.mavenized.herolanguage.ui/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>my.mavenized.herolanguage.ui</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/my.mavenized.herolanguage.ui/.settings/org.eclipse.core.resources.prefs
+++ b/my.mavenized.herolanguage.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/my.mavenized.herolanguage.ui/.settings/org.eclipse.m2e.core.prefs
+++ b/my.mavenized.herolanguage.ui/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/my.mavenized.herolanguage.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/my.mavenized.herolanguage.ui/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,7 @@
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/main/java.directory=xtend-gen
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/test/java.directory=src/test/generated-sources/xtend
+BuilderConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
+outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
+outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/my.mavenized.herolanguage.updatesite/.project
+++ b/my.mavenized.herolanguage.updatesite/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>my.mavenized.herolanguage.updatesite</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/my.mavenized.herolanguage.updatesite/.settings/org.eclipse.core.resources.prefs
+++ b/my.mavenized.herolanguage.updatesite/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/my.mavenized.herolanguage.updatesite/.settings/org.eclipse.m2e.core.prefs
+++ b/my.mavenized.herolanguage.updatesite/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/my.mavenized.herolanguage/.settings/org.eclipse.core.resources.prefs
+++ b/my.mavenized.herolanguage/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/my.mavenized.herolanguage/.settings/org.eclipse.m2e.core.prefs
+++ b/my.mavenized.herolanguage/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/my.mavenized.herolanguage/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/my.mavenized.herolanguage/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,0 +1,7 @@
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/main/java.directory=xtend-gen
+//outlet.DEFAULT_OUTPUT.sourceFolder.src/test/java.directory=src/test/generated-sources/xtend
+BuilderConfiguration.is_project_specific=true
+eclipse.preferences.version=1
+outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
+outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
+outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true


### PR DESCRIPTION
.project, .classpath and .settings folders should be present in the Git repository for every project. I don't see why it wasn't the case before.

It makes easier to simply import them in the workspace.