### PR TITLE
Cache dependencies in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
+      - name: Cache Maven, p2 and Gradle dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2
+            ~/.gradle
+            !~/.m2/**/*mavenized*
+            !~/.m2/**/*example*
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2-
       - name: Build
         run: |
           mvn clean install -U
           cd example-project
-          mvn clean install -U
+          mvn clean verify -U
           cd ../example-project-gradle
           ./gradlew clean build


### PR DESCRIPTION
This should speed up the builds (note that the artifacts of this example, if installed, will not be parted of the saved cache).

Note also that it's useless to install our example-project: "verify" is enough